### PR TITLE
Update /cmd/live/thief.c

### DIFF
--- a/cmd/live/thief.c
+++ b/cmd/live/thief.c
@@ -752,6 +752,16 @@ steal(string str)
         return 1;
     }
 
+    /*
+     * Do not allow theft in locations where others are prevented
+     * from retaliation.
+     */
+    if (environment(this_player())->query_prop(ROOM_M_NO_ATTACK))
+    {
+        write("You may not " + query_verb() + " in this place.\n");
+        return 1;
+    }
+
     /* Don't allow people to try a steal attempt in rapid succession. */
     /* Moved even further up to avoid the messages being sent to players
      * unnecessarily due to obnoxious command spamming.


### PR DESCRIPTION
Block the steal command where the ROOM_M_NO_ATTACK prop is present to prevent exploitation by thieves where they can steal but players are blocked from retaliation from inside the room.