### PR TITLE
New 'friend' command to filter behaviour of "intimate" option.

### DIFF
--- a/doc/help/general/friend
+++ b/doc/help/general/friend
@@ -1,0 +1,22 @@
+NAME
+        friend - grant or remove friendship to another person
+
+SYNOPSIS
+	friend [list]
+	friend add <name>
+	friend remove <name>
+
+DESCRIPTION
+	Normally people are open to accepting all emotions from others.
+	With the friend command you may limit who is allowed to perform
+	some types of "intimate" emotions on you if you have turned that
+	option off.
+
+OPTIONS
+        [none] - Show who you have granted friendship to.
+
+	add    - Add <name> to your list of friends.
+	remove - Remove <name> from your list of friends.
+
+SEE ALSO
+	options

--- a/doc/help/general/options
+++ b/doc/help/general/options
@@ -36,7 +36,8 @@ ARGUMENTS
 			      individual players.
 
 	intimate <on/off>   - Indicate whether you are in the mood for the use
-			      of intimate emotes.
+			      of intimate emotes. When "off", you may filter
+			      who you accept them from. See "help friend".
 
 	inventory <on/off>  - Indicate whether you want to view your inventory
 			      in a modern tabulated display, or not.

--- a/std/player.c
+++ b/std/player.c
@@ -958,6 +958,8 @@ load_player(string pl_name)
         m_gift_reject = ([ ]);
     if (!mappingp(m_gift_today))
         m_gift_today = ([ ]);
+    if (!mappingp(m_friends_list))
+        m_friends_list = ([ ]);
     if (!mappingp(m_bits))
         m_bits = ([ ]);
     if (!mappingp(m_vars))

--- a/std/player/cmd_sec.c
+++ b/std/player/cmd_sec.c
@@ -500,7 +500,8 @@ change_password(string str)
 public mixed
 block_action(string cmd, object target, object actor, int cmd_type)
 {
-    if ((cmd_type & ACTION_INTIMATE) && query_option(OPT_BLOCK_INTIMATE))
+    if ((cmd_type & ACTION_INTIMATE) && query_option(OPT_BLOCK_INTIMATE) &&
+        !query_friendship(actor->query_real_name()))
     {
         return query_The_name(actor) + " is not in the mood for intimate behaviour.\n";
     }

--- a/std/player/savevars_sec.c
+++ b/std/player/savevars_sec.c
@@ -56,6 +56,7 @@ private mapping m_remember_name,        /* Names of players we have met */
 		m_gift_reject,		/* Players we reject gifts from */
                 m_bits,                 /* The domain bits of the player. */
 		m_vars,                 /* Some less used variables. */
+                m_friends_list,         /* Players we consider friends */
                 m_alias_list,           /* Aliases for the quicktyper */
                 m_nick_list;            /* Nick(name)s for the quicktyper */
 private object  logout_location;        /* The last logout / saving location */
@@ -1625,6 +1626,56 @@ remove_gift_reject(string name)
         return 0;
 
     m_delkey(m_gift_reject, name);
+    return 1;
+}
+
+/*
+ * Function name: query_friendship
+ * Description  : Find out whether we name is a friend of the player, or
+ *                the names of all who we consider friends.
+ * Arguments    : string name - the name to check, or 0
+ * Returns      : int 1/0, or an array of names.
+ */
+public mixed
+query_friendship(string name)
+{
+    if (name)
+        return m_friends_list[lower_case(name)];
+    else
+        return m_indices(m_friends_list);
+}
+
+/*
+ * Function name: add_friendship
+ * Description  : Add a name to the players list of friends.
+ * Arguments    : string name - the name of the player to add.
+ * Returns      : int 1 = added, 0 = already added.
+ */
+public int
+add_friendship(string name)
+{
+    name = lower_case(name);
+    if (m_friends_list[name])
+        return 0;
+
+    m_friends_list[name] = 1;
+    return 1;
+}
+
+/*
+ * Function name: remove_friendship
+ * Description  : Remove a name from the players list of friends.
+ * Arguments    : string name - the name of the player to remove.
+ * Returns      : int 1 = removed, 0 = wasn't present.
+ */
+public int
+remove_friendship(string name)
+{
+    name = lower_case(name);
+    if (!m_friends_list[name])
+        return 0;
+
+    m_delkey(m_friends_list, name);
     return 1;
 }
 


### PR DESCRIPTION
New "friend" command to allow filtered emotes through. Currently only applies to "intimate" classed emotes.