### PR TITLE
Acrobatic defence

### DIFF
--- a/std/combat/cbase.c
+++ b/std/combat/cbase.c
@@ -122,6 +122,14 @@ compute_acrobat_evade(object vic)
 {
     int a_aid, evade, h = 0;
 
+    /*
+     * Enforce that non-humanoids have 0 effective SS_ACROBAT skill.
+     */
+    if (!vic->query_humanoid())
+    {
+        return 0;
+    }
+
     evade = vic->query_skill(SS_ACROBAT);
     /*
      * No need to proceed further


### PR DESCRIPTION
Fixed role reversal of attacker/defender in cached (for optimization) value of adjusted acrobat evade levels.

Added check for humanoid when computing how much effective SS_ACROBAT to apply. Non-humanoids now get 0 benefit.
