### PR TITLE
Increase Stat Compare Levels

### DIFF
--- a/cmd/live/state.c
+++ b/cmd/live/state.c
@@ -422,8 +422,8 @@ adverbs(string str)
 void
 compare_living(object living1, object living2)
 {
-    /* Allow the player high precision up to 3x their skill vs stat average */
-    int skill = this_player()->query_skill(SS_APPR_MON) * 3;
+    /* Allow the player high precision up to 4x their skill vs stat average */
+    int skill = this_player()->query_skill(SS_APPR_MON) * 4;
     int seed  = atoi(OB_NUM(living1)) + atoi(OB_NUM(living2));
     int index = -1;
     int stat1;

--- a/cmd/live/thief.c
+++ b/cmd/live/thief.c
@@ -1065,6 +1065,8 @@ steal(string str)
     /* We're stealing, apply cost */
     this_player()->add_mana(-F_STEAL_MANA);
     this_player()->add_fatigue(-F_STEAL_FATIGUE);
+	/* Stealing gives us adrenaline */
+	this_player()->update_combat_time();
 
     /* Setup the thieves base chances.. */
     tmp  = this_player()->query_skill(SS_SNEAK);

--- a/sys/state_desc.h
+++ b/sys/state_desc.h
@@ -206,7 +206,7 @@
 			   "clearly stronger than", "much stronger than"})
 #define SD_COMPARE_DEX  ({ "about as agile as", 			  \
 			   "barely better coordinated than", "somewhat more agile than",	  \
-			   "more agile than", "clearly more agile", "much more agile than" })
+			   "more agile than", "clearly more agile than", "much more agile than" })
 #define SD_COMPARE_CON  ({ "about as healthy as", "barely healthier than", \
 			   "somewhat healthier than", "healthier than", "clearly healthier than", \
                "much healthier than"})

--- a/sys/state_desc.h
+++ b/sys/state_desc.h
@@ -202,19 +202,23 @@
     "degraded", "somewhat degraded", "slightly degraded", "in full vigour" })
 
 #define SD_COMPARE_STR  ({ "about the same strength as", 		  \
-			   "a bit stronger than", "stronger than", 	  \
-			   "much stronger than"})
+			   "barely stronger than", "somewhat stronger than",  "stronger than", 	  \
+			   "clearly stronger than", "much stronger than"})
 #define SD_COMPARE_DEX  ({ "about as agile as", 			  \
-			   "a bit better coordinated than", 		  \
-			   "more agile than", "much more agile than" })
-#define SD_COMPARE_CON  ({ "about as healthy as", "a bit healthier than", \
-			   "healthier than", "much healthier than"})
-#define SD_COMPARE_INT  ({ "about as smart as", "a bit smarter than",     \
-			   "smarter than", "much smarter than"})
-#define SD_COMPARE_WIS  ({ "about as wise as", "a bit wiser than",        \
-			   "wiser than", "much wiser than"})
-#define SD_COMPARE_DIS  ({ "about as brave as", "a bit braver than",      \
-			   "braver than", "much braver than"})
+			   "barely better coordinated than", "somewhat more agile than",	  \
+			   "more agile than", "clearly more agile", "much more agile than" })
+#define SD_COMPARE_CON  ({ "about as healthy as", "barely healthier than", \
+			   "somewhat healthier than", "healthier than", "clearly healthier than", \
+               "much healthier than"})
+#define SD_COMPARE_INT  ({ "about as smart as", "barely smarter than",     \
+			   "somewhat smarter than", "smarter than", \
+               "clearly smarter than", "much smarter than"})
+#define SD_COMPARE_WIS  ({ "about as wise as", "barely wiser than",        \
+			   "somewhat wiser than", "wiser than", \
+               "clearly wiser than", "much wiser than"})
+#define SD_COMPARE_DIS  ({ "about as brave as", "barely braver than",      \
+			   "somewhat braver than", "braver than", \
+               "clearly braver than", "much braver than"})
 #define SD_COMPARE_AC   ({ "about the same protection as",                \
                            "a bit more protection than",                  \
                            "more protection than",                        \


### PR DESCRIPTION
Accomodate a much larger average player and npc size by increasing precision of compare stats:

Increases stat compare descriptions from 4 levels to 6 levels:
about the same, barely more, somewhat more, more, clearly more, much more

Increases precision of appraise enemy skill from 3x skill to 4x skill
